### PR TITLE
trivial issue in php_self function with unusual port numbers

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -637,14 +637,14 @@ class tmhOAuth {
    */
   function php_self($dropqs=true) {
     $url = sprintf('%s://%s%s',
-      $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https',
+      $_SERVER['HTTPS'] ? 'https' : 'http',
       $_SERVER['SERVER_NAME'],
       $_SERVER['REQUEST_URI']
     );
 
     $parts = parse_url($url);
 
-    $port = @$parts['port'];
+    $port = $_SERVER['SERVER_PORT'];
     $scheme = $parts['scheme'];
     $host = $parts['host'];
     $path = @$parts['path'];


### PR DESCRIPTION
Hi Matt,

php_self function returns "https://host/" scheme when the server is listening on port other than 80 or 443.
This is problematic when running tmhOAuth on XAMPP or MAMP server which listens on port 8888 by default.

I'm sending a pull request which should resolve the issue.

Best regards,
Yusuke Yamamoto
