### PR TITLE
Add target option to tmhUtilities->entify to specify link target

### DIFF
--- a/tmhUtilities.php
+++ b/tmhUtilities.php
@@ -16,7 +16,7 @@ class tmhUtilities {
    * @param array $tweet the json converted to normalised array
    * @return the tweet text with entities replaced with hyperlinks
    */
-  function entify($tweet, &$replacements=array()) {
+  function entify($tweet, &$replacements=array(), $target = "") {
     $encoding = mb_internal_encoding();
     mb_internal_encoding("UTF-8");
 
@@ -32,18 +32,22 @@ class tmhUtilities {
     if (!isset($tweet['entities'])) {
       return $tweet['text'];
     }
+	
+	if(!empty($target)) {
+		$target = "target=\"$target\"";
+	}
 
     // prepare the entities
     foreach ($tweet['entities'] as $type => $things) {
       foreach ($things as $entity => $value) {
-        $tweet_link = "<a href=\"http://twitter.com/{$tweet['user']['screen_name']}/statuses/{$tweet['id']}\">{$tweet['created_at']}</a>";
+        $tweet_link = "<a $target href=\"http://twitter.com/{$tweet['user']['screen_name']}/statuses/{$tweet['id']}\">{$tweet['created_at']}</a>";
 
         switch ($type) {
           case 'hashtags':
-            $href = "<a href=\"http://twitter.com/search?q=%23{$value['text']}\">#{$value['text']}</a>";
+            $href = "<a $target href=\"http://twitter.com/search?q=%23{$value['text']}\">#{$value['text']}</a>";
             break;
           case 'user_mentions':
-            $href = "@<a href=\"http://twitter.com/{$value['screen_name']}\" title=\"{$value['name']}\">{$value['screen_name']}</a>";
+            $href = "@<a $target href=\"http://twitter.com/{$value['screen_name']}\" title=\"{$value['name']}\">{$value['screen_name']}</a>";
             break;
           case 'urls':
           case 'media':
@@ -51,7 +55,7 @@ class tmhUtilities {
             $display = isset($value['display_url']) ? $value['display_url'] : str_replace('http://', '', $url);
             // Not all pages are served in UTF-8 so you may need to do this ...
             $display = urldecode(str_replace('%E2%80%A6', '&hellip;', urlencode($display)));
-            $href = "<a href=\"{$value['url']}\">{$display}</a>";
+            $href = "<a $target href=\"{$value['url']}\">{$display}</a>";
             break;
         }
         $keys[$value['indices']['0']] = mb_substr(

--- a/tmhUtilities.php
+++ b/tmhUtilities.php
@@ -41,20 +41,20 @@ class tmhUtilities {
     }
 	
 	if(!empty($this->linkTarget)) {
-		$target = "target=\"{$this->linkTarget}\"";
+		$this->linkTarget = "target=\"{$this->linkTarget}\"";
 	}
 
     // prepare the entities
     foreach ($tweet['entities'] as $type => $things) {
       foreach ($things as $entity => $value) {
-        $tweet_link = "<a $target href=\"http://twitter.com/{$tweet['user']['screen_name']}/statuses/{$tweet['id']}\">{$tweet['created_at']}</a>";
+        $tweet_link = "<a {$this->linkTarget} href=\"http://twitter.com/{$tweet['user']['screen_name']}/statuses/{$tweet['id']}\">{$tweet['created_at']}</a>";
 
         switch ($type) {
           case 'hashtags':
-            $href = "<a $target href=\"http://twitter.com/search?q=%23{$value['text']}\">#{$value['text']}</a>";
+            $href = "<a {$this->linkTarget} href=\"http://twitter.com/search?q=%23{$value['text']}\">#{$value['text']}</a>";
             break;
           case 'user_mentions':
-            $href = "@<a $target href=\"http://twitter.com/{$value['screen_name']}\" title=\"{$value['name']}\">{$value['screen_name']}</a>";
+            $href = "@<a {$this->linkTarget} href=\"http://twitter.com/{$value['screen_name']}\" title=\"{$value['name']}\">{$value['screen_name']}</a>";
             break;
           case 'urls':
           case 'media':
@@ -62,7 +62,7 @@ class tmhUtilities {
             $display = isset($value['display_url']) ? $value['display_url'] : str_replace('http://', '', $url);
             // Not all pages are served in UTF-8 so you may need to do this ...
             $display = urldecode(str_replace('%E2%80%A6', '&hellip;', urlencode($display)));
-            $href = "<a $target href=\"{$value['url']}\">{$display}</a>";
+            $href = "<a {$this->linkTarget} href=\"{$value['url']}\">{$display}</a>";
             break;
         }
         $keys[$value['indices']['0']] = mb_substr(

--- a/tmhUtilities.php
+++ b/tmhUtilities.php
@@ -10,13 +10,20 @@
  * 29 September 2011
  */
 class tmhUtilities {
+  
+  /**
+   *
+   * @var string Target for links created by entify()
+   */
+  public $linkTarget = "";
+  
   /**
    * Entifies the tweet using the given entities element
    *
    * @param array $tweet the json converted to normalised array
    * @return the tweet text with entities replaced with hyperlinks
    */
-  function entify($tweet, &$replacements=array(), $target = "") {
+  function entify($tweet, &$replacements=array()) {
     $encoding = mb_internal_encoding();
     mb_internal_encoding("UTF-8");
 
@@ -33,8 +40,8 @@ class tmhUtilities {
       return $tweet['text'];
     }
 	
-	if(!empty($target)) {
-		$target = "target=\"$target\"";
+	if(!empty($this->linkTarget)) {
+		$target = "target=\"{$this->linkTarget}\"";
 	}
 
     // prepare the entities


### PR DESCRIPTION
In my code I would like processed links to open in a new window.  I added a $linkTarget member variable to the tmhUtilties class which, when specified, inserts target="$this->linkTarget" into links generated by the entify method.
