### PR TITLE
Removed strtolower() when preparing URL.

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -244,7 +244,7 @@ class tmhOAuth {
         || ($scheme == 'http' && $port != '80')) {
       $host = "$host:$port";
     }
-    $this->url = strtolower("$scheme://$host$path");
+    $this->url = "$scheme://$host$path";
   }
 
   /**

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -244,7 +244,11 @@ class tmhOAuth {
         || ($scheme == 'http' && $port != '80')) {
       $host = "$host:$port";
     }
-    $this->url = "$scheme://$host$path";
+    
+    // the scheme and host MUST be lowercase
+    $this->url = strtolower("$scheme://$host");
+    // but not the path
+    $this->url .= $path;
   }
 
   /**


### PR DESCRIPTION
Some providers, like LinkedIn, uses a case-sensitive URL which includes capital letters.

Some examples: 
https://api.linkedin.com/uas/oauth/requestToken
https://api.linkedin.com/uas/oauth/accessToken

Reference: https://developer.linkedin.com/documents/linkedins-oauth-details
