### PR TITLE
Fixed composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,7 @@
 {
   "name": "themattharris/tmhOAuth",
-  "extra": {
-     "branch-alias": {
-       "dev-master": "0.7.2-devel"
-     }
-  },
   "type": "library",
   "description": "An OAuth 1.0A library written in PHP by @themattharris, specifically for use with the Twitter API",
-  "version": "0.7.2",
   "license": "Apache-2.0",
   "authors": [
     {
@@ -24,31 +18,9 @@
     "issues": "https://github.com/themattharris/tmhOAuth/issues"
   },
   "require": {
-    "php": ">=5.3.0",
-    "themattharris/tmhOAuth": "0.7.2"
-  },
-  "repositories": {
-    "tmhOAuth": {
-      "type": "package",
-      "package": {
-        "name": "themattharris/tmhOAuth",
-        "description": "An OAuth 1.0A library written in PHP by @themattharris, specifically for use with the Twitter API.",
-        "version": "0.7.2",
-        "dist": {
-          "url": "https://github.com/themattharris/tmhOAuth/zipball/0.7.2-devel",
-          "type": "zip"
-        },
-        "source": {
-          "url": "https://github.com/themattharris/tmhOAuth.git",
-          "type": "git",
-          "reference": "0.7.2"
-        }
-      }
-    }
+    "php": ">=5.3.0"
   },
   "autoload": {
-    "classmap": [
-      "./tmhOAuth.php"
-    ]
+    "psr-0": { "Themattharris": "src/" }
   }
 }


### PR DESCRIPTION
I tried using https://github.com/themattharris/tmhOAuth.git with `composer`, by adding

```
{
    "type": "vcs",
    "url": "git://github.com/themattharris/tmhOAuth.git"
},
"require": {
    "themattharris/tmhOAuth": "master" (or "dev-master")
}
```

to my app's `composer.json` and ran `composer install`, but it always pulled the 0.7.2-devel branch, and not the master.

I then tried

```
"require": {
    "themattharris/tmhOAuth": "0.7.2"
}
```

but for some reason `composer` fails to even process the entry then.

I then tried

```
"require": {
    "themattharris/tmhOAuth": "*"
}
```

and still got the 0.7.2 branch.

I then reviewed https://github.com/themattharris/tmhOAuth/blob/master/composer.json and see that the package requires itself! (https://github.com/themattharris/tmhOAuth/blob/master/composer.json#L28). It also hardcodes the version, and the classmap is wrong.

I tested the updated `composer.json`, and it works fine. Please use it.
