### PR TITLE
The library shouldn't alter PHP's default timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ vast majority of hosting providers include these libraries and run with PHP 5.1+
 The code makes use of hash_hmac, which was introduced in PHP 5.1.2. If your version
 of PHP is lower than this you should ask your hosting provider for an update.
 
+To prevent warnings from being triggered, you should also make sure that the `date.timezone` directive in your `php.ini` is properly set. For more information, see the notes at http://php.net/date_default_timezone_set
+
 ## A note about security and SSL
 
 Version 0.60 hardened the security of the library and defaulted `curl_ssl_verifypeer` to `true`.

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -34,8 +34,6 @@ class tmhOAuth {
         // leave 'user_agent' blank for default, otherwise set this to
         // something that clearly identifies your app
         'user_agent'                 => '',
-        // default timezone for requests
-        'timezone'                   => 'UTC',
 
         'use_ssl'                    => true,
         'host'                       => 'api.twitter.com',
@@ -86,7 +84,6 @@ class tmhOAuth {
       $config
     );
     $this->set_user_agent();
-    date_default_timezone_set($this->config['timezone']);
   }
 
   /**


### PR DESCRIPTION
IMHO the fix for #70 should be reverted. It's not up to a library to try and fix the user's PHP environment in case their setup is broken and their date.timezone php.ini directive is not set.

The only result is to unexpectedly change the timezone whenever the library is used, setting it to UTC by default. Requiring the user to pass the correct timezone as a config variable doesn't seem to be a sane option either.
