### PR TITLE
Fixed minor bug (discovered while repurposing the signing part of your code)

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -303,7 +303,7 @@ class tmhOAuth {
     }
 
     // auth params = the default oauth params which are present in our collection of signing params
-    $this->auth_params = array_intersect_key($this->get_defaults(), $_signing_params);
+    $this->auth_params = array_intersect_key($_signing_params, $this->get_defaults());
     if (isset($_signing_params['oauth_callback'])) {
       $this->auth_params['oauth_callback'] = $_signing_params['oauth_callback'];
       unset($_signing_params['oauth_callback']);


### PR DESCRIPTION
Bug in array_intersect_key call, I'm sure you intended to extract from the _signing_params array the values that also appear in the array returned from the function get_defaults, as opposed to the other way around (which would conceptually make no sense, despite working)
