### PR TITLE
Support for `CurlFile` for multipart requests to prevent deprecated warnings in PHP 5.5

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -297,6 +297,8 @@ class tmhOAuth {
    * @return string the original or modified string, depending on the request and the input parameter
    */
   private function multipart_escape($value) {
+    if (class_exists('CurlFile', false) && is_object($value) && $value instanceof CurlFile)
+      return $value;
     if (! $this->request_settings['multipart'] || strpos($value, '@') !== 0)
       return $value;
 
@@ -366,7 +368,9 @@ class tmhOAuth {
         }
       }
       $prepared[$k] = $v;
-      $prepared_pairs[] = "{$k}={$v}";
+
+      if (!is_object($v) || !class_exists('CurlFile', false) || !($v instanceof CurlFile))
+        $prepared_pairs[] = "{$k}={$v}";
     }
 
     if ($doing_oauth1) {


### PR DESCRIPTION
Example call:

``` php
$client->request('POST', 'https://api.twitter.com/1.1/statuses/update_with_media.json', array(
  'status' => 'Posting a photo',
  'media[]' => new CurlFile('my-file.jpg'),
), true, true);
```
