### PR TITLE
Update curl options to handle methods beyond GET and PUT

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -765,7 +765,7 @@ class tmhOAuth {
         break;
       case 'POST':
         curl_setopt($c, CURLOPT_POST, true);
-				// intentional fall-through
+        // intentional fall-through
       case 'PUT':
         if (isset($this->request_settings['postfields']))
           $postfields = $this->request_settings['postfields'];

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -38,6 +38,7 @@ class tmhOAuth {
         // something that clearly identifies your app
         'user_agent'                 => '',
         'host'                       => 'api.twitter.com',
+        'method'                     => 'GET',
 
         'consumer_key'               => '',
         'consumer_secret'            => '',

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -379,6 +379,7 @@ class tmhOAuth {
 
       switch ($this->request_settings['method']) {
         case 'POST':
+        case 'PUT':
           $this->request_settings['postfields'] = $this->request_settings['multipart'] ? $prepared : $content;
           break;
         default:
@@ -763,6 +764,8 @@ class tmhOAuth {
         break;
       case 'POST':
         curl_setopt($c, CURLOPT_POST, true);
+				// intentional fall-through
+      case 'PUT':
         if (isset($this->request_settings['postfields']))
           $postfields = $this->request_settings['postfields'];
         else
@@ -774,6 +777,8 @@ class tmhOAuth {
         if (isset($this->request_settings['postfields']))
           curl_setopt($c, CURLOPT_CUSTOMREQUEST, $this->request_settings['postfields']);
     }
+
+    curl_setopt($c, CURLOPT_CUSTOMREQUEST, $this->request_settings['method']);
 
     curl_setopt_array($c, array(
       CURLOPT_HTTP_VERSION   => $this->config['curl_http_version'],


### PR DESCRIPTION
Now handles PUT (and DELETE) type requests as well, which are required for some Twitter API calls. Tested with PUT calls to Twitter API and it works successfully.

Also sets a default 'method' in the default options, just for reference's sake.
