### PR TITLE
Allows curl to work in AWS enviroment

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -783,7 +783,7 @@ class tmhOAuth {
       CURLOPT_RETURNTRANSFER => true,
       CURLOPT_SSL_VERIFYPEER => $this->config['curl_ssl_verifypeer'],
       CURLOPT_SSL_VERIFYHOST => $this->config['curl_ssl_verifyhost'],
-
+      CURLOPT_SSLVERSION     => 3,
       CURLOPT_FOLLOWLOCATION => $this->config['curl_followlocation'],
       CURLOPT_PROXY          => $this->config['curl_proxy'],
       CURLOPT_ENCODING       => $this->config['curl_encoding'],


### PR DESCRIPTION
AWS environment has somewhat broken curl - need to set SSLVERSION to 3 for it to work from PHP
