### PR TITLE
RSA-based and SHA-256-involving signature methods

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -46,6 +46,8 @@ class tmhOAuth {
         'secret'                     => '',
 
         // RSA private key (for RSA-SHA1 and RSA-SHA256 methods)
+        // Please note that this is expected to be a string representing
+        // the PEM-formatted key itself and NOT the file name
         'private_key_pem'            => '',
 
         // OAuth2 bearer token. This should already be URL encoded

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -496,7 +496,13 @@ class tmhOAuth {
    * @return binary signature
    */
   private function sign_with_rsa($algorithm) {
-    openssl_sign($this->request_settings['basestring'], $signature, $this->config['private_key_pem'], $algorithm);
+    if ($this->config['private_key_pem'] == '') {
+      throw new Exception("No private key PEM is configured, cannot sign");
+    }
+    $ok = openssl_sign($this->request_settings['basestring'], $signature, $this->config['private_key_pem'], $algorithm);
+    if (!$ok) {
+      throw new Exception("Cannot sign: " . openssl_error_string()); 
+    }
     return $signature;
   }
 

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -464,10 +464,10 @@ class tmhOAuth {
         $signature = $this->sign_with_hmac('sha256');
         break;
       case 'RSA-SHA1':
-        $signature = $this->sign_with_rsa('sha1');
+        $signature = $this->sign_with_rsa(OPENSSL_ALGO_SHA1);
         break;
       case 'RSA-SHA256':
-        $signature = $this->sign_with_rsa('sha256');
+        $signature = $this->sign_with_rsa(OPENSSL_ALGO_SHA256);
         break;
       default:
         throw new Exception("Unsupported oauth_signature_method: '" . $this->config['oauth_signature_method'] . "'");
@@ -476,7 +476,7 @@ class tmhOAuth {
   }
 
   /**
-   * Signs the OAuth 1 request with HMAC-based signature
+   * Signs the OAuth 1 request using HMAC-based signature algorithm
    *
    * @param string $algorithm algorithm name (like sha1 or sha256)
    * @return binary signature
@@ -488,11 +488,12 @@ class tmhOAuth {
   }
 
   /**
-   * Signs the OAuth 1 request with RSA-based signature
+   * Signs the OAuth 1 request using RSA-based signature algorithm
    *
-   * @param string $algorithm name of hash algorithm that will be
-   * used to compute base string hash before encrypting it with RSA
-   * (like sha1 or sha256)
+   * @param mixed $algorithm ID or name of hash algorithm that will be
+   * used to compute base string hash before encrypting it with RSA;
+   * values understood by openssl_sign()'s $signature_alg parameter
+   * are accepted here (like 'sha1' or OPENSSL_ALGO_SHA256)
    * @return binary signature
    */
   private function sign_with_rsa($algorithm) {

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -499,6 +499,9 @@ class tmhOAuth {
    * @return binary signature
    */
   private function sign_with_rsa($algorithm) {
+    if (!function_exists('openssl_sign')) {
+      throw new Exception("openssl_sign function does not exist. Please make sure Openssl extension is installed");
+    }
     if ($this->config['private_key_pem'] == '') {
       throw new Exception("No private key PEM is configured, cannot sign");
     }

--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -7,14 +7,14 @@
  * REST requests. OAuth authentication is sent using an Authorization Header.
  *
  * @author themattharris
- * @version 0.8.4
+ * @version 0.8.5
  *
- * 06 Aug 2014
+ * 09 Jun 2017
  */
 defined('__DIR__') or define('__DIR__', dirname(__FILE__));
 
 class tmhOAuth {
-  const VERSION = '0.8.4';
+  const VERSION = '0.8.5';
   var $response = array();
 
   /**


### PR DESCRIPTION
- added support for the following signature methods: RSA-SHA1, RSA-SHA256, HMAC-SHA256 (the third and second methods are non-standard extensions)

RSA-SHA1 is a standard signature method defined by OAuth 1.0a. It is nice to have it implemented.

As for RSA-SHA256, it is non-standard, but now, when SHA1 is compromised in practice, RSA-SHA1 does not seem to provide enough security. Hence RSA-SHA256 may be useful for clients and servers that will to use asymmetric signatures and not suffer from a weak signature algorithm.

HMAC-SHA1 does not seem to be compromised, but HMAC-SHA256 (again, a non-standard signature method) support was added for completeness.