### PR TITLE
Handles json post data

### DIFF
--- a/tmhOAuth.php
+++ b/tmhOAuth.php
@@ -654,6 +654,10 @@ class tmhOAuth {
    * @return bool
    */
   private function isJson($string) {
+    if (!is_string($string)) {
+        return false;
+    }
+
     json_decode($string);
 
     return (json_last_error() == JSON_ERROR_NONE);


### PR DESCRIPTION
Allows sending json payload in POST requests for the new DM endpoints.

`$this->post('direct_messages/events/new', json_encode($array));`

This addresses themattharris/tmhOAuth#199 and themattharris/tmhOAuth#195.